### PR TITLE
On Mac, target macOS 10.9 when possible (fixes build on XCode 10+)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Parts of this file were taken from the pandas project
+# (https://github.com/pandas-dev/pandas), which is permitted for use under
+# the BSD 3-Clause License
+
+from distutils.sysconfig import get_config_var
+from distutils.version import LooseVersion
+import os
+import platform
 from setuptools import setup, Extension
+import sys
+
+
+# From https://github.com/pandas-dev/pandas/pull/24274:
+# For mac, ensure extensions are built for macos 10.9 when compiling on a
+# 10.9 system or above, overriding distuitls behaviour which is to target
+# the version that python was built for. This may be overridden by setting
+# MACOSX_DEPLOYMENT_TARGET before calling setup.py
+if sys.platform == 'darwin':
+    if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
+        current_system = LooseVersion(platform.mac_ver()[0])
+        python_target = LooseVersion(
+            get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        if python_target < '10.9' and current_system >= '10.9':
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
+
 
 sasl_module = Extension('sasl.saslwrapper',
                         sources=['sasl/saslwrapper.cpp'],


### PR DESCRIPTION
This patch aims to fix an issue where `python-sasl` cannot be compiled with newer versions of XCode. In particular, this library fails to compile out-of-the-box on OS X Mojave (see https://github.com/cloudera/thrift_sasl/issues/15).

The problem seems to be related to missing `stdlibc++` headers, which are not installed by default in XCode 10+.

To fix this issue, I copied changes from https://github.com/pandas-dev/pandas/pull/24274 (with proper attribution). Quoting from that patch description:

> For extension builds, `distutils` targets the same macOS version as python was built for, even if the host system is newer. This can cause problems when building on a 10.9+ system, with a python built for <10.9. Targetting macOS <10.9 sets the c++ standard library to `stdlibc++`, which was deprecated in 10.9 in favour of `libc++`. Starting with Xcode 10, `stdlibc++` is no longer installed by default, so isn't guaranteed to be available. This can be an issue with the current 64/32b universal builds of python, which target macOS 10.7.
> 
> Another reason to do this is to move over to 10.9 / `libc++` where possible, as the current 64-bit builds of python have done.

This worked for me and I think it's a simpler approach than some of the other workarounds suggested in https://github.com/cloudera/thrift_sasl/issues/15 and https://github.com/hkwi/python-geohash/issues/27 because it doesn't require the installation of additional headers or commandline tools. I have little experience with native code builds, however, so please chime in if I'm overlooking something.