### PR TITLE
Convert `get_config_var` return to string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.platform == 'darwin':
     if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
         current_system = LooseVersion(platform.mac_ver()[0])
         python_target = LooseVersion(
-            get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+            str(get_config_var('MACOSX_DEPLOYMENT_TARGET')))
         if python_target < '10.9' and current_system >= '10.9':
             os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 


### PR DESCRIPTION
I was getting issues installing `sasl==0.3.1`:

```
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/81/kqvp0vjx63gfg5cbczsprwp00000gp/T/pip-install-4567bfnx/sasl_c72464a3686149948899242d98362bd1/setup.py", line 35, in <module>
      python_target = LooseVersion(
    File "/usr/local/Cellar/python@3.8/3.8.9/Frameworks/Python.framework/Versions/3.8/lib/python3.8/distutils/version.py", line 304, in __init__
      self.parse(vstring)
    File "/usr/local/Cellar/python@3.8/3.8.9/Frameworks/Python.framework/Versions/3.8/lib/python3.8/distutils/version.py", line 312, in parse
      components = [x for x in self.component_re.split(vstring)
  TypeError: expected string or bytes-like object
```

The specific source of the problem is that `get_config_var('MACOSX_DEPLOYMENT_TARGET')` was returning the integer `11`

This is a bug that was shipped in Python3.8 and Python3.9: https://bugs.python.org/issue42504

The comment above this section of code references a code pattern from Pandas.  Pandas also experienced this bug
and fixed it here: https://github.com/pandas-dev/pandas/pull/38766

This commit implements the same fix.

As a workaround while this is prepped for release, I was able to `export MACOSX_DEPLOYMENT_TARGET=11` 
prior to running the install so that it skipped over the broken code.