### PR TITLE
Fix error C3861: 'getpass': identifier not found on Win32

### DIFF
--- a/sasl/saslwrapper.h
+++ b/sasl/saslwrapper.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <string>
 #include <sasl/sasl.h>
+#include <sasl/saslutil.h>
 #include <sstream>
 #include <stdlib.h>
 #include <string.h>

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,13 @@ if sys.platform == 'darwin':
             os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
 
+extra_compile_args = ["/DWIN32"] if sys.platform == "win32" else []
+
 sasl_module = Extension('sasl.saslwrapper',
                         sources=['sasl/saslwrapper.cpp'],
                         include_dirs=["sasl"],
                         libraries=["sasl2"],
+                        extra_compile_args=extra_compile_args,
                         language="c++")
 setup(name='sasl',
       version='0.3.1',
@@ -56,5 +59,6 @@ setup(name='sasl',
       packages=['sasl'],
       install_requires=['six'],
       ext_modules=[sasl_module],
+      package_data={'sasl': ['*.dll']},
       include_package_data=True,
       license='Apache License, Version 2.0')


### PR DESCRIPTION
Fixes
```
python-sasl-0.3.1\sasl\saslwrapper.h(442): error C3861: 'getpass': identifier not found
error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX86\\x64\\cl.exe' failed with exit status 2
```

Also adds option to distribute extra DLL files.